### PR TITLE
Corrected code references to file name- WormGoGeneMapping.tsv. Fixes #1

### DIFF
--- a/scripts/elastic_search/worm.py
+++ b/scripts/elastic_search/worm.py
@@ -63,9 +63,9 @@ class WormBase(MOD):
             }
 
     def load_go(self):
-        go_data_csv_filename = "data/WormGOGeneMapping.tsv"
+        go_data_csv_filename = "data/WormGoGeneMapping.tsv"
 
-        print("Fetching go data from WormBase txt file...")
+        print("Fetching go data from WormBase tsv file...")
 
         with open(go_data_csv_filename, 'rb') as f:
             reader = csv.reader(f, delimiter='\t')


### PR DESCRIPTION
This is a defect-fix for linux where the index may not build since the file name referenced in the code does not exactly make the physical file's name (difference in letter-case on the second 'o')- Line 65. The change in line 68 was tagged-along out of convenience. 